### PR TITLE
Return file path after screenshot

### DIFF
--- a/lib/ozzie.dart
+++ b/lib/ozzie.dart
@@ -62,6 +62,7 @@ class Ozzie {
       final pixels = await driver.screenshot();
       await file.writeAsBytes(pixels);
       print('Ozzie took screenshot: $filePath');
+      return filePath;
     }
   }
 


### PR DESCRIPTION
Return file path after screenshot. Then we can compare the screenshot with a reference image.