### PR TITLE
feat(custom paths): Allow passing in a rootFolderName

### DIFF
--- a/lib/ozzie.dart
+++ b/lib/ozzie.dart
@@ -7,19 +7,21 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'reporter.dart';
 import 'zip_generator.dart';
 
-const rootFolderName = "ozzie";
-
 /// [Ozzie] is the class responsible for taking screenshots and generating
 /// an HTML report when running your integrationt tests on Flutter.
 class Ozzie {
   final FlutterDriver driver;
+  final String basePath;
   final String groupName;
+  final String rootFolderName;
   final bool shouldTakeScreenshots;
-  var _doesGroupFolderNeedToBeDeleted = true;
+  bool _doesGroupFolderNeedToBeDeleted = true;
 
   Ozzie._internal(
     this.driver, {
+    this.basePath,
     @required this.groupName,
+    @required this.rootFolderName,
     @required this.shouldTakeScreenshots,
   }) : assert(driver != null);
 
@@ -39,12 +41,12 @@ class Ozzie {
     FlutterDriver driver, {
     String groupName = "default",
     bool shouldTakeScreenshots = true,
+    String rootFolderName = "ozzie",
   }) =>
-      Ozzie._internal(
-        driver,
-        groupName: groupName,
-        shouldTakeScreenshots: shouldTakeScreenshots,
-      );
+      Ozzie._internal(driver,
+          groupName: groupName,
+          shouldTakeScreenshots: shouldTakeScreenshots,
+          rootFolderName: rootFolderName);
 
   /// It takes a an PNG screnshot of the given state of the application when
   /// being called. The name of the screenshot will be the given `screenshotName`
@@ -123,7 +125,8 @@ class Ozzie {
 
   String get _groupFolderName => '$rootFolderName/$groupName';
 
-  String get _timestamp => DateTime.now().toIso8601String();
+  String get _timestamp =>
+      DateTime.now().toIso8601String().replaceAll(':', '.');
 
   String _fileName(String screenshotName) => '$_timestamp-$screenshotName.png';
 

--- a/test/ozzie_test.dart
+++ b/test/ozzie_test.dart
@@ -28,8 +28,8 @@ void main() {
   });
 
   tearDown(() async {
-    if (await Directory(rootFolderName).exists()) {
-      await Directory(rootFolderName).delete(recursive: true);
+    if (await Directory(ozzie.rootFolderName).exists()) {
+      await Directory(ozzie.rootFolderName).delete(recursive: true);
     }
   });
 
@@ -51,7 +51,8 @@ void main() {
 
     test('not taking screenshots still generates an HTML report', () async {
       await ozzie.generateHtmlReport();
-      final fileExists = await File('$rootFolderName/index.html').exists();
+      final fileExists =
+          await File('${ozzie.rootFolderName}/index.html').exists();
       expect(fileExists, isTrue);
     });
 
@@ -66,7 +67,7 @@ void main() {
     group('with screenshots enabled', () {
       test('on first takeScreenshot call the the group folder is deleted',
           () async {
-        final filePath = '$rootFolderName/$testGroupName';
+        final filePath = '${ozzie.rootFolderName}/$testGroupName';
         var testFile = await File('$filePath/testFile').create(recursive: true);
         testFile.writeAsBytes([1, 2, 3]);
         await ozzie.takeScreenshot('alex');
@@ -83,8 +84,9 @@ void main() {
 
       test('takeScreenshot generates PNGs containing given name', () async {
         await ozzie.takeScreenshot('rim');
-        final files =
-            Directory('$rootFolderName/$testGroupName').listSync().toList();
+        final files = Directory('${ozzie.rootFolderName}/$testGroupName')
+            .listSync()
+            .toList();
         final resultFile =
             files.where((f) => f is File).map((f) => f as File).first;
         expect(true, resultFile.path.contains('rim.png'));
@@ -95,7 +97,7 @@ void main() {
             () async {
           await ozzie.takeScreenshot('alex');
           final isHtmlReportGenerated =
-              await File('$rootFolderName/index.html').exists();
+              await File('${ozzie.rootFolderName}/index.html').exists();
           expect(false, isHtmlReportGenerated);
         });
 
@@ -103,7 +105,7 @@ void main() {
           await ozzie.takeScreenshot('alex');
           await ozzie.generateHtmlReport();
           final isHtmlReportGenerated =
-              await File('$rootFolderName/index.html').exists();
+              await File('${ozzie.rootFolderName}/index.html').exists();
           expect(true, isHtmlReportGenerated);
         });
       });
@@ -126,7 +128,7 @@ void main() {
         );
         await noScreenshotsOzzie.takeScreenshot('alex');
         final isHtmlReportGenerated =
-            await File('$rootFolderName/index.html').exists();
+            await File('${ozzie.rootFolderName}/index.html').exists();
         expect(false, isHtmlReportGenerated);
       });
     });


### PR DESCRIPTION
https://github.com/bmw-tech/ozzie.flutter/issues/2

Moved rootFolderName into the constructor and gave it a default value of "ozzie" like before.

The user can now override the rootFolderName by passing in a named argument into the constructor.

I'm new to open source contributions so please let me know if I forgot something :)

